### PR TITLE
feat(ui): 优化主题切换逻辑，支持实时跟随 QQ 主题及目标导向的切换按钮

### DIFF
--- a/app/src/main/java/me/yxp/qfun/activity/BaseComposeActivity.kt
+++ b/app/src/main/java/me/yxp/qfun/activity/BaseComposeActivity.kt
@@ -35,13 +35,23 @@ abstract class BaseComposeActivity : ComponentActivity() {
         updateStatusBarAppearance()
     }
 
+    override fun onResume() {
+        super.onResume()
+        checkAndUpdateTheme()
+    }
+
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)
         if (hasFocus && Build.VERSION.SDK_INT < 30) {
             (lifecycle as LifecycleRegistry).handleLifecycleEvent(Lifecycle.Event.ON_START)
         }
-        
-        if (hasFocus && themeMode == ThemeHelper.MODE_AUTO) {
+        if (hasFocus) {
+            checkAndUpdateTheme()
+        }
+    }
+
+    private fun checkAndUpdateTheme() {
+        if (themeMode == ThemeHelper.MODE_AUTO) {
             val newNightMode = ThemeHelper.isNightMode()
             if (isDarkTheme != newNightMode) {
                 isDarkTheme = newNightMode
@@ -64,8 +74,12 @@ abstract class BaseComposeActivity : ComponentActivity() {
     }
 
     protected fun toggleTheme() {
-        
-        themeMode = (themeMode + 1) % 3
+        // 如果当前是自动模式，点击后根据当前状态切换为强制深色或浅色
+        // 如果当前是强制模式，点击后恢复为自动模式
+        themeMode = when (themeMode) {
+            ThemeHelper.MODE_AUTO -> if (isDarkTheme) ThemeHelper.MODE_LIGHT else ThemeHelper.MODE_DARK
+            else -> ThemeHelper.MODE_AUTO
+        }
         ThemeHelper.setThemeMode(themeMode)
         isDarkTheme = ThemeHelper.isNightMode()
         ThemeHelper.applyTheme(this)

--- a/app/src/main/java/me/yxp/qfun/activity/PluginActivity.kt
+++ b/app/src/main/java/me/yxp/qfun/activity/PluginActivity.kt
@@ -40,6 +40,7 @@ class PluginActivity : BaseComposeActivity() {
                         isLocalRefreshing = vm.isLocalRefreshing,
                         isOnlineRefreshing = vm.isOnlineRefreshing,
                         themeMode = themeMode,
+                        isDarkTheme = isDarkTheme,
                         onThemeToggle = ::toggleTheme,
                         onBackClick = ::finish,
                         onCreatePlugin = vm::showCreatePluginDialog,

--- a/app/src/main/java/me/yxp/qfun/activity/SettingActivity.kt
+++ b/app/src/main/java/me/yxp/qfun/activity/SettingActivity.kt
@@ -43,6 +43,7 @@ class SettingActivity : BaseComposeActivity() {
                         categories = vm.categories,
                         versionInfo = vm.buildVersionInfo(),
                         themeMode = themeMode,
+                        isDarkTheme = isDarkTheme,
                         onThemeToggle = ::toggleTheme,
                         onImportConfig = ::startImportConfig,
                         onExportConfig = ::startExportConfig,

--- a/app/src/main/java/me/yxp/qfun/ui/components/molecules/QFunTopBar.kt
+++ b/app/src/main/java/me/yxp/qfun/ui/components/molecules/QFunTopBar.kt
@@ -43,6 +43,7 @@ fun QFunTopBar(
     showBackButton: Boolean = false,
     onBackClick: () -> Unit = {},
     themeMode: Int = 0,
+    isDarkTheme: Boolean = false,
     onThemeToggle: () -> Unit = {},
     actions: @Composable () -> Unit = {}
 ) {
@@ -94,13 +95,11 @@ fun QFunTopBar(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 val iconRes = when(themeMode) {
-                    1 -> R.drawable.ic_sun
-                    2 -> R.drawable.ic_moon
+                    0 -> if (isDarkTheme) R.drawable.ic_sun else R.drawable.ic_moon
                     else -> R.drawable.ic_theme_auto
                 }
                 val themeText = when(themeMode) {
-                    1 -> "浅色"
-                    2 -> "深色"
+                    0 -> if (isDarkTheme) "浅色" else "深色"
                     else -> "跟随"
                 }
 

--- a/app/src/main/java/me/yxp/qfun/ui/pages/plugin/PluginScreen.kt
+++ b/app/src/main/java/me/yxp/qfun/ui/pages/plugin/PluginScreen.kt
@@ -97,6 +97,7 @@ fun PluginScreen(
     isLocalRefreshing: Boolean,
     isOnlineRefreshing: Boolean,
     themeMode: Int,
+    isDarkTheme: Boolean,
     onThemeToggle: () -> Unit,
     onBackClick: () -> Unit,
     onCreatePlugin: () -> Unit,
@@ -131,6 +132,7 @@ fun PluginScreen(
             showBackButton = true,
             onBackClick = onBackClick,
             themeMode = themeMode,
+            isDarkTheme = isDarkTheme,
             onThemeToggle = onThemeToggle,
             actions = {
                 TopBarCapsuleButton(

--- a/app/src/main/java/me/yxp/qfun/ui/pages/settings/SettingsScreen.kt
+++ b/app/src/main/java/me/yxp/qfun/ui/pages/settings/SettingsScreen.kt
@@ -77,6 +77,7 @@ fun SettingsScreen(
     categories: List<CategoryData>,
     versionInfo: String,
     themeMode: Int,
+    isDarkTheme: Boolean,
     onThemeToggle: () -> Unit,
     onImportConfig: () -> Unit,
     onExportConfig: () -> Unit,
@@ -131,6 +132,7 @@ fun SettingsScreen(
                         categories = categories,
                         versionInfo = versionInfo,
                         themeMode = themeMode,
+                        isDarkTheme = isDarkTheme,
                         onThemeToggle = onThemeToggle,
                         onUpdateLogClick = onUpdateLogClick,
                         onImportConfig = onImportConfig,
@@ -147,6 +149,7 @@ fun SettingsScreen(
                         DetailPage(
                             category = category,
                             themeMode = themeMode,
+                            isDarkTheme = isDarkTheme,
                             onThemeToggle = onThemeToggle,
                             onBackClick = { selectedCategoryName = null },
                             onFunctionToggle = onFunctionToggle,
@@ -230,6 +233,7 @@ private fun MainPage(
     categories: List<CategoryData>,
     versionInfo: String,
     themeMode: Int,
+    isDarkTheme: Boolean,
     onThemeToggle: () -> Unit,
     onUpdateLogClick: () -> Unit,
     onImportConfig: () -> Unit,
@@ -250,6 +254,7 @@ private fun MainPage(
             QFunTopBar(
                 title = "QFun",
                 themeMode = themeMode,
+                isDarkTheme = isDarkTheme,
                 onThemeToggle = onThemeToggle,
                 actions = {
                     TopBarCapsuleButton(
@@ -342,6 +347,7 @@ private fun AboutSection(
 private fun DetailPage(
     category: CategoryData,
     themeMode: Int,
+    isDarkTheme: Boolean,
     onThemeToggle: () -> Unit,
     onBackClick: () -> Unit,
     onFunctionToggle: (String, Boolean) -> Unit,
@@ -353,6 +359,7 @@ private fun DetailPage(
             showBackButton = true,
             onBackClick = onBackClick,
             themeMode = themeMode,
+            isDarkTheme = isDarkTheme,
             onThemeToggle = onThemeToggle
         )
         LazyColumn(


### PR DESCRIPTION
**背景与动机 (Motivation):**
当前的主题切换逻辑（Auto -> Light -> Dark 的三态循环）在某些场景下不够直观，且如果用户通过 QQ 侧边栏或系统设置切换了深浅色模式，返回模块界面时主题状态可能无法即时同步更新。

**核心修改 (Key Changes):**
1. **实时跟随 QQ 主题**：
   - 在 `BaseComposeActivity` 中补充了 `onResume()` 的生命周期监听。
   - 现已支持：无论用户是通过手机系统切换深色模式，还是通过 QQ 侧边栏独立切换主题，只要返回模块界面，模块就会立即检测并同步 QQ 的最新明暗状态。

2. **目标导向的主题切换按钮**：
   - 优化了 `QFunTopBar` 中主题切换按钮的 UI 反馈逻辑。
   - 当处于**“自动跟随”**模式时，按钮将显示**相反（目标）**的主题图标：
     - 若当前 QQ 为浅色，按钮显示“深色（月亮）”，点击即强制深色。
     - 若当前 QQ 为深色，按钮显示“浅色（太阳）”，点击即强制浅色。
   - 当处于**强制模式**（强制深色/浅色）时，按钮显示“跟随（自动）”，点击即恢复跟随 QQ 状态。
   - 这种二态+跟随的逻辑更符合用户的直觉操作。

3. **状态传递优化**：
   - 将真实的明暗状态 `isDarkTheme` 向下传递给了 `SettingsScreen`、`PluginScreen` 及 `QFunTopBar`，确保 Compose 能够精准响应主题的真实物理状态，而不仅仅是响应模式（Mode）的变化。

**测试建议 (How to test):**
1. 保持模块处于“跟随”模式，在 QQ 侧边栏切换夜间模式，再打开模块，观察模块是否自动变黑。
2. 观察模块右上角的切换按钮，在跟随浅色时是否显示为“深色”，点击后是否立刻变为深色，且图标变为“跟随”。