### PR TITLE
fix: 悬浮球竞态及 CrashActivity NPE 修复

### DIFF
--- a/app/src/main/java/me/yxp/qfun/hook/api/OnMenuBuild.kt
+++ b/app/src/main/java/me/yxp/qfun/hook/api/OnMenuBuild.kt
@@ -101,7 +101,7 @@ object OnMenuBuild : BaseApiHookItem<MenuClickListener>(), DexKitTask {
         key: String,
         aioMsgItem: AIOMsgItem
     ) {
-        val context = QQCurrentEnv.activity ?: QQCurrentEnv.qQAppInterface.application
+        val context = QQCurrentEnv.activity ?: QQCurrentEnv.qQAppInterface!!.application
         val newItem = itemClass.newInstanceWithArgs(context, aioMsgItem)
         newItem.setObjectByType(key)
         items.add(0, newItem)

--- a/app/src/main/java/me/yxp/qfun/hook/msg/CustomRandomFace.kt
+++ b/app/src/main/java/me/yxp/qfun/hook/msg/CustomRandomFace.kt
@@ -139,7 +139,7 @@ object CustomRandomFace : BaseSwitchHookItem() {
 
         toServiceMsg.addAttribute("req_pb_protocol_flag", true)
 
-        QQCurrentEnv.qQAppInterface.sendToService(toServiceMsg)
+        QQCurrentEnv.qQAppInterface!!.sendToService(toServiceMsg)
 
     }
 

--- a/app/src/main/java/me/yxp/qfun/plugin/view/PluginView.kt
+++ b/app/src/main/java/me/yxp/qfun/plugin/view/PluginView.kt
@@ -52,6 +52,16 @@ import java.io.File
 import kotlin.math.abs
 
 class PluginView(private val activity: Activity) {
+    companion object {
+        @Volatile
+        private var currentInstance: PluginView? = null
+
+        fun dismissCurrent() {
+            currentInstance?.dismiss()
+            currentInstance = null
+        }
+    }
+
     private var popupWindow: PopupWindow? = null
     private var floatBtn: View? = null
     private var lastX = 0
@@ -66,7 +76,10 @@ class PluginView(private val activity: Activity) {
 
     fun show() {
         ThemeHelper.applyTheme(activity)
-        if (popupWindow != null) return
+        if (popupWindow != null) {
+            dismiss()
+        }
+        currentInstance = this
         val currentContact = PluginViewLoader.currentContact
         PluginManager.plugins.filter { it.isRunning }
             .forEach {
@@ -117,24 +130,41 @@ class PluginView(private val activity: Activity) {
 
         setupTouchListener()
 
-        ModuleScope.launchMain {
-            try {
-                ensurePositionInScreen()
-                popupWindow?.showAtLocation(
-                    activity.window.decorView,
-                    Gravity.NO_GRAVITY,
-                    lastX,
-                    lastY
-                )
-            } catch (_: Exception) {
+        try {
+            if (activity.isFinishing || activity.isDestroyed) {
+                return
             }
+
+            ensurePositionInScreen()
+
+            val decorView = activity.window.decorView
+            decorView.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+                override fun onViewAttachedToWindow(v: View) {}
+                override fun onViewDetachedFromWindow(v: View) {
+                    dismiss()
+                    decorView.removeOnAttachStateChangeListener(this)
+                }
+            })
+
+            popupWindow?.showAtLocation(
+                decorView,
+                Gravity.NO_GRAVITY,
+                lastX,
+                lastY
+            )
+        } catch (_: Exception) {
         }
     }
 
     fun dismiss() {
-        ModuleScope.launchMain {
+        try {
             popupWindow?.dismiss()
+        } catch (_: Exception) {
+        } finally {
             popupWindow = null
+            if (currentInstance == this) {
+                currentInstance = null
+            }
         }
     }
 

--- a/app/src/main/java/me/yxp/qfun/plugin/view/PluginViewLoader.kt
+++ b/app/src/main/java/me/yxp/qfun/plugin/view/PluginViewLoader.kt
@@ -11,6 +11,7 @@ import me.yxp.qfun.plugin.loader.PluginManager
 import me.yxp.qfun.utils.hook.hookAfter
 import me.yxp.qfun.utils.qq.FriendTool
 import me.yxp.qfun.utils.qq.QQCurrentEnv
+import kotlinx.coroutines.Job
 
 @HookItemAnnotation("监听聊天界面")
 object PluginViewLoader : BaseApiHookItem<Listener>() {
@@ -27,6 +28,8 @@ object PluginViewLoader : BaseApiHookItem<Listener>() {
     private var currentPluginView: PluginView? = null
     private var aioDelegate: AIODelegate? = null
 
+    private var showJob: Job? = null
+
     val currentContact: PluginContact
         get() = aioDelegate?.let {
             parseToPluginContact(it.aioContact.toString())
@@ -36,20 +39,25 @@ object PluginViewLoader : BaseApiHookItem<Listener>() {
 
         AIODelegate::class.java.getDeclaredMethod("show")
             .hookAfter(this) {
-                aioDelegate = it.thisObject as AIODelegate
+                val targetDelegate = it.thisObject as AIODelegate
+                aioDelegate = targetDelegate
 
                 if (currentContact.chatType != 0) {
                     hideView()
-                    showView()
+                    showView(targetDelegate)
                 }
-
-
             }
+
         AIODelegate::class.java.getDeclaredMethod("hide")
             .hookAfter(this) {
-                if (QQCurrentEnv.activity !is ScaleAIOActivity) hideView()
-            }
+                val targetDelegate = it.thisObject as AIODelegate
 
+                if (QQCurrentEnv.activity !is ScaleAIOActivity) {
+                    if (aioDelegate == targetDelegate) {
+                        hideView()
+                    }
+                }
+            }
     }
 
     private fun parseToPluginContact(input: String): PluginContact {
@@ -80,12 +88,15 @@ object PluginViewLoader : BaseApiHookItem<Listener>() {
         )
     }
 
-    private fun showView() {
+    private fun showView(expectedDelegate: AIODelegate) {
+        showJob?.cancel()
 
-        ModuleScope.launchMainDelayed(1) {
-            val activity = QQCurrentEnv.activity ?: return@launchMainDelayed
+        showJob = ModuleScope.launchMain {
+            if (aioDelegate != expectedDelegate) return@launchMain
+            val activity = QQCurrentEnv.activity ?: return@launchMain
 
             if (PluginManager.plugins.any { it.isRunning && it.compiler.menuItems.isNotEmpty() }) {
+                PluginView.dismissCurrent()
                 currentPluginView = PluginView(activity)
                 currentPluginView?.show()
             }
@@ -93,8 +104,10 @@ object PluginViewLoader : BaseApiHookItem<Listener>() {
     }
 
     private fun hideView() {
+        showJob?.cancel()
+        showJob = null
+
         currentPluginView?.dismiss()
         currentPluginView = null
     }
-
 }

--- a/app/src/main/java/me/yxp/qfun/utils/qq/CookieTool.kt
+++ b/app/src/main/java/me/yxp/qfun/utils/qq/CookieTool.kt
@@ -9,7 +9,7 @@ import mqq.manager.TicketManager
 object CookieTool {
 
     private val manager
-        get() = QQCurrentEnv.qQAppInterface.getManager(2) as TicketManager
+        get() = QQCurrentEnv.qQAppInterface!!.getManager(2) as TicketManager
 
     fun getRealSkey(): String? = manager.getRealSkey(QQCurrentEnv.currentUin)
     fun getSkey(): String? = manager.getSkey(QQCurrentEnv.currentUin)

--- a/app/src/main/java/me/yxp/qfun/utils/qq/QQCurrentEnv.kt
+++ b/app/src/main/java/me/yxp/qfun/utils/qq/QQCurrentEnv.kt
@@ -25,8 +25,8 @@ object QQCurrentEnv {
         )
     }
 
-    val qQAppInterface
-        get() = MobileQQ.getMobileQQ().peekAppRuntime() as QQAppInterface
+    val qQAppInterface: QQAppInterface?
+        get() = MobileQQ.getMobileQQ().peekAppRuntime() as? QQAppInterface
 
     val activity: Activity?
         get() = runCatching {
@@ -55,13 +55,13 @@ object QQCurrentEnv {
 
     val currentUin: String
         get() = runCatching {
-            qQAppInterface.currentUin
+            qQAppInterface?.currentUin ?: ""
         }.getOrElse {
             globalPreference.getString("currentUin", "global")!!
         }
 
     val currentNickName: String?
-        get() = qQAppInterface.currentNickname
+        get() = qQAppInterface?.currentNickname
 
     val kernelMsgService
         get() = runCatching {
@@ -87,9 +87,9 @@ internal inline fun <reified T : QRouteApi> api(): T {
 }
 
 internal inline fun <reified T : IRuntimeService> runtime(): T {
-    return QQCurrentEnv.qQAppInterface.getRuntimeService(T::class.java, "")
+    return QQCurrentEnv.qQAppInterface!!.getRuntimeService(T::class.java, "")
 }
 
 internal inline fun <reified T : BusinessHandler> handler(): BusinessHandler {
-    return QQCurrentEnv.qQAppInterface.getBusinessHandler(T::class.java.name)
+    return QQCurrentEnv.qQAppInterface!!.getBusinessHandler(T::class.java.name)
 }

--- a/app/src/main/java/me/yxp/qfun/utils/qq/TroopTool.kt
+++ b/app/src/main/java/me/yxp/qfun/utils/qq/TroopTool.kt
@@ -124,7 +124,7 @@ object TroopTool {
                 addAttribute("req_pb_protocol_flag", true)
             }
 
-            QQCurrentEnv.qQAppInterface.sendToService(toServiceMsg)
+            QQCurrentEnv.qQAppInterface!!.sendToService(toServiceMsg)
             val actionText = if (enable) "设置管理成功" else "取消管理成功"
             Toasts.qqToast(2, actionText)
             return
@@ -213,7 +213,7 @@ object TroopTool {
             addAttribute("req_pb_protocol_flag", true)
         }
 
-        QQCurrentEnv.qQAppInterface.sendToService(toServiceMsg)
+        QQCurrentEnv.qQAppInterface!!.sendToService(toServiceMsg)
         Toasts.qqToast(2, "设置头衔成功")
     }
 

--- a/app/src/main/java/me/yxp/qfun/utils/ui/ThemeHelper.kt
+++ b/app/src/main/java/me/yxp/qfun/utils/ui/ThemeHelper.kt
@@ -25,7 +25,9 @@ object ThemeHelper {
         return when (getThemeMode()) {
             MODE_LIGHT -> false
             MODE_DARK -> true
-            else -> ThemeUtil.isInNightMode(QQCurrentEnv.qQAppInterface)
+            else -> QQCurrentEnv.qQAppInterface?.let {
+                ThemeUtil.isInNightMode(it)
+            } ?: false
         }
     }
 


### PR DESCRIPTION
- PluginView: dismiss 改为同步执行，新增 dismissCurrent() 静态方法，消除与 showView 的竞态
- PluginViewLoader: showView 校验 delegate 身份，hide 钩子校验 delegate 一致性
- ThemeHelper: isNightMode 对 qQAppInterface 判空，崩溃场景下不 NPE
- QQCurrentEnv: qQAppInterface 改为可空类型 as?，关联调用处加 !! 断言