### PR TITLE
fix(msg): sendPtt 发出的语音消息异常

### DIFF
--- a/app/src/main/java/me/yxp/qfun/plugin/api/PluginMethod.kt
+++ b/app/src/main/java/me/yxp/qfun/plugin/api/PluginMethod.kt
@@ -187,6 +187,15 @@ class PluginMethod(private val compiler: PluginCompiler) {
         runWithErrorHandle { MsgTool.sendPtt(contact, path) }
     }
 
+    /** durationMs 单位毫秒；<=0 时从 silk 估算 */
+    fun sendPtt(peerUin: String, path: String, chatType: Int, durationMs: Int) {
+        runWithErrorHandle { MsgTool.sendPtt(peerUin, path, chatType, durationMs) }
+    }
+
+    fun sendPtt(contact: Contact, path: String, durationMs: Int) {
+        runWithErrorHandle { MsgTool.sendPtt(contact, path, durationMs) }
+    }
+
     fun sendCard(peerUin: String, data: String, chatType: Int) {
         runWithErrorHandle { MsgTool.sendCard(peerUin, data, chatType) }
     }

--- a/app/src/main/java/me/yxp/qfun/utils/qq/MsgTool.kt
+++ b/app/src/main/java/me/yxp/qfun/utils/qq/MsgTool.kt
@@ -139,7 +139,7 @@ object MsgTool : DexKitTask {
                 msgUtilApiImpl.createPicElement(path, true, 0)
             }
 
-            "ptt" -> msgUtilApiImpl.createPttElement(value, 0, ArrayList<Byte>())
+            "ptt" -> msgUtilApiImpl.createPttElement(value, estimatePttDurationMs(value), ArrayList())
             "video" -> msgUtilApiImpl.createVideoElement(value)
             "file" -> msgUtilApiImpl.createFileElement(value)
             "ark" -> {
@@ -160,6 +160,29 @@ object MsgTool : DexKitTask {
         sendMsgByType(makeContact(peerUin, chatType), value, type)
     }
 
+    // createPttElement 的 duration 为毫秒，宿主会 round(ms/1000) 写入秒
+    private fun estimatePttDurationMs(path: String): Int {
+        return runCatching {
+            val bytes = File(path).takeIf { it.exists() && it.length() > 0L }?.readBytes()
+                ?: return@runCatching 1000
+            var offset = when {
+                bytes.size >= 10 && String(bytes, 1, 9, Charsets.US_ASCII) == "#!SILK_V3" -> 10
+                bytes.size >= 9 && String(bytes, 0, 9, Charsets.US_ASCII) == "#!SILK_V3" -> 9
+                else -> return@runCatching 1000
+            }
+            var frames = 0
+            while (offset + 2 <= bytes.size) {
+                val frameLen = (bytes[offset].toInt() and 0xff) or
+                        ((bytes[offset + 1].toInt() and 0xff) shl 8)
+                offset += 2
+                if (frameLen <= 0 || frameLen > 4096 || offset + frameLen > bytes.size) break
+                offset += frameLen
+                frames++
+            }
+            if (frames <= 0) 1000 else frames * 20
+        }.getOrDefault(1000).coerceAtLeast(1000)
+    }
+
     fun sendPic(peerUin: String, path: String, chatType: Int) {
         sendMsgByType(peerUin, chatType, path, "pic")
     }
@@ -174,6 +197,15 @@ object MsgTool : DexKitTask {
 
     fun sendPtt(peerUin: String, path: String, chatType: Int) {
         sendMsgByType(peerUin, chatType, path, "ptt")
+    }
+
+    fun sendPtt(contact: Contact, path: String, durationMs: Int) {
+        val ms = if (durationMs > 0) durationMs else estimatePttDurationMs(path)
+        sendMsg(contact, arrayListOf(msgUtilApiImpl.createPttElement(path, ms.coerceAtLeast(1000), ArrayList())))
+    }
+
+    fun sendPtt(peerUin: String, path: String, chatType: Int, durationMs: Int) {
+        sendPtt(makeContact(peerUin, chatType), path, durationMs)
     }
 
     fun sendCard(contact: Contact, data: String) {

--- a/app/src/main/java/me/yxp/qfun/utils/qq/MsgTool.kt
+++ b/app/src/main/java/me/yxp/qfun/utils/qq/MsgTool.kt
@@ -139,10 +139,7 @@ object MsgTool : DexKitTask {
                 msgUtilApiImpl.createPicElement(path, true, 0)
             }
 
-            "ptt" -> {
-                val ms = estimatePttDurationMs(value)
-                msgUtilApiImpl.createPttElement(value, ms, defaultPttWaveAmplitudes(ms))
-            }
+            "ptt" -> buildPttElement(value)
             "video" -> msgUtilApiImpl.createVideoElement(value)
             "file" -> msgUtilApiImpl.createFileElement(value)
             "ark" -> {
@@ -186,19 +183,17 @@ object MsgTool : DexKitTask {
         }.getOrDefault(1000).coerceAtLeast(1000)
     }
 
-    /**
-     * QQ 气泡波形：PttElement.waveAmplitudes 为空时语音条可能不显示。
-     * createPttElement 第三参即写入该字段；官方录音侧会填真实振幅，脚本侧给一组非空假波形即可。
-     */
+    // waveAmplitudes 为空时部分版本语音条不显示；第三参写入该字段
     private fun defaultPttWaveAmplitudes(durationMs: Int): ArrayList<Byte> {
-        var n = durationMs / 40
-        if (n < 20) n = 20
-        if (n > 120) n = 120
-        val waves = ArrayList<Byte>(n)
-        for (i in 0 until n) {
-            waves.add((15 + ((i * 7) % 70)).toByte())
+        val n = (durationMs / 40).coerceIn(20, 120)
+        return ArrayList<Byte>(n).apply {
+            for (i in 0 until n) add((15 + (i * 7) % 70).toByte())
         }
-        return waves
+    }
+
+    private fun buildPttElement(path: String, durationMs: Int = 0): MsgElement {
+        val ms = (if (durationMs > 0) durationMs else estimatePttDurationMs(path)).coerceAtLeast(1000)
+        return msgUtilApiImpl.createPttElement(path, ms, defaultPttWaveAmplitudes(ms))
     }
 
     fun sendPic(peerUin: String, path: String, chatType: Int) {
@@ -218,8 +213,7 @@ object MsgTool : DexKitTask {
     }
 
     fun sendPtt(contact: Contact, path: String, durationMs: Int) {
-        val ms = (if (durationMs > 0) durationMs else estimatePttDurationMs(path)).coerceAtLeast(1000)
-        sendMsg(contact, arrayListOf(msgUtilApiImpl.createPttElement(path, ms, defaultPttWaveAmplitudes(ms))))
+        sendMsg(contact, arrayListOf(buildPttElement(path, durationMs)))
     }
 
     fun sendPtt(peerUin: String, path: String, chatType: Int, durationMs: Int) {

--- a/app/src/main/java/me/yxp/qfun/utils/qq/MsgTool.kt
+++ b/app/src/main/java/me/yxp/qfun/utils/qq/MsgTool.kt
@@ -139,7 +139,10 @@ object MsgTool : DexKitTask {
                 msgUtilApiImpl.createPicElement(path, true, 0)
             }
 
-            "ptt" -> msgUtilApiImpl.createPttElement(value, estimatePttDurationMs(value), ArrayList())
+            "ptt" -> {
+                val ms = estimatePttDurationMs(value)
+                msgUtilApiImpl.createPttElement(value, ms, defaultPttWaveAmplitudes(ms))
+            }
             "video" -> msgUtilApiImpl.createVideoElement(value)
             "file" -> msgUtilApiImpl.createFileElement(value)
             "ark" -> {
@@ -183,6 +186,21 @@ object MsgTool : DexKitTask {
         }.getOrDefault(1000).coerceAtLeast(1000)
     }
 
+    /**
+     * QQ 气泡波形：PttElement.waveAmplitudes 为空时语音条可能不显示。
+     * createPttElement 第三参即写入该字段；官方录音侧会填真实振幅，脚本侧给一组非空假波形即可。
+     */
+    private fun defaultPttWaveAmplitudes(durationMs: Int): ArrayList<Byte> {
+        var n = durationMs / 40
+        if (n < 20) n = 20
+        if (n > 120) n = 120
+        val waves = ArrayList<Byte>(n)
+        for (i in 0 until n) {
+            waves.add((15 + ((i * 7) % 70)).toByte())
+        }
+        return waves
+    }
+
     fun sendPic(peerUin: String, path: String, chatType: Int) {
         sendMsgByType(peerUin, chatType, path, "pic")
     }
@@ -200,8 +218,8 @@ object MsgTool : DexKitTask {
     }
 
     fun sendPtt(contact: Contact, path: String, durationMs: Int) {
-        val ms = if (durationMs > 0) durationMs else estimatePttDurationMs(path)
-        sendMsg(contact, arrayListOf(msgUtilApiImpl.createPttElement(path, ms.coerceAtLeast(1000), ArrayList())))
+        val ms = (if (durationMs > 0) durationMs else estimatePttDurationMs(path)).coerceAtLeast(1000)
+        sendMsg(contact, arrayListOf(msgUtilApiImpl.createPttElement(path, ms, defaultPttWaveAmplitudes(ms))))
     }
 
     fun sendPtt(peerUin: String, path: String, chatType: Int, durationMs: Int) {

--- a/doc/Plugin API.md
+++ b/doc/Plugin API.md
@@ -166,9 +166,7 @@ list.forEach(this::log);
 - **方法重载 3**：`sendPtt(String PeerUin, String 语音路径, int 聊天类型, int durationMs)`
 - **方法重载 4**：`sendPtt(Object Contact对象, String 语音路径, int durationMs)`
 
-> `durationMs` 为毫秒。不传时从 silk 估算；失败回退 `1000ms`。
->
-> 实现会自动写入非空 `waveAmplitudes`（气泡波形数据）。空列表时部分 QQ 版本语音条不显示；无需脚本自行传 wave。
+> `durationMs` 为毫秒；不传时从 silk 估算，失败回退 `1000ms`。会自动写入非空 `waveAmplitudes`（空列表时部分版本语音条不显示）。
 
 #### 4. sendCard：发送 JSON 卡片
 - **方法重载 1**：`sendCard(String PeerUin, String JSON字符串, int 聊天类型)`

--- a/doc/Plugin API.md
+++ b/doc/Plugin API.md
@@ -167,6 +167,8 @@ list.forEach(this::log);
 - **方法重载 4**：`sendPtt(Object Contact对象, String 语音路径, int durationMs)`
 
 > `durationMs` 为毫秒。不传时从 silk 估算；失败回退 `1000ms`。
+>
+> 实现会自动写入非空 `waveAmplitudes`（气泡波形数据）。空列表时部分 QQ 版本语音条不显示；无需脚本自行传 wave。
 
 #### 4. sendCard：发送 JSON 卡片
 - **方法重载 1**：`sendCard(String PeerUin, String JSON字符串, int 聊天类型)`

--- a/doc/Plugin API.md
+++ b/doc/Plugin API.md
@@ -166,7 +166,7 @@ list.forEach(this::log);
 - **方法重载 3**：`sendPtt(String PeerUin, String 语音路径, int 聊天类型, int durationMs)`
 - **方法重载 4**：`sendPtt(Object Contact对象, String 语音路径, int durationMs)`
 
-> `durationMs` 为毫秒；不传时从 silk 估算，失败回退 `1000ms`。会自动写入非空 `waveAmplitudes`（空列表时部分版本语音条不显示）。
+> `durationMs` 为毫秒；不传时从 silk 估算，失败回退 `1000ms`。
 
 #### 4. sendCard：发送 JSON 卡片
 - **方法重载 1**：`sendCard(String PeerUin, String JSON字符串, int 聊天类型)`

--- a/doc/Plugin API.md
+++ b/doc/Plugin API.md
@@ -163,6 +163,10 @@ list.forEach(this::log);
 #### 3. sendPtt：发送语音
 - **方法重载 1**：`sendPtt(String PeerUin, String 语音路径, int 聊天类型)`
 - **方法重载 2**：`sendPtt(Object Contact对象, String 语音路径)`
+- **方法重载 3**：`sendPtt(String PeerUin, String 语音路径, int 聊天类型, int durationMs)`
+- **方法重载 4**：`sendPtt(Object Contact对象, String 语音路径, int durationMs)`
+
+> `durationMs` 为毫秒。不传时从 silk 估算；失败回退 `1000ms`。
 
 #### 4. sendCard：发送 JSON 卡片
 - **方法重载 1**：`sendCard(String PeerUin, String JSON字符串, int 聊天类型)`


### PR DESCRIPTION
## Bug Description

脚本 API `sendPtt` 发出的语音消息可能出现：

- 气泡不显示 / 空气泡 / 无法正常播放

根因在 `MsgTool` 原先：

```kotlin
"ptt" -> msgUtilApiImpl.createPttElement(value, 0, ArrayList<Byte>())
```

两个问题：

1. **duration 固定为 0**  
2. **waveAmplitudes 空列表**

## Fix

1. 默认从本地 silk 估算 `durationMs`（支持 `#!SILK_V3` 与 `rateIndex + #!SILK_V3`，20ms/帧）；失败回退 `1000ms`
2. 新增带 `durationMs` 的 `sendPtt` 重载
3. **自动写入非空 `waveAmplitudes`**（按时长 20~120 点假波形；脚本无需自己传）
4. 更新 `doc/Plugin API.md`

## API（兼容）

旧调用不变：

```java
sendPtt(peerUin, path, chatType);
sendPtt(contact, path);
```

新增：

```java
sendPtt(peerUin, path, chatType, durationMs);
sendPtt(contact, path, durationMs);
```

## How to Verify

1. 脚本发送本地 silk：
   ```java
   sendPtt(peer, "/sdcard/test.silk", 2);
   ```
2. 气泡应正常显示，时长接近真实秒数
3. 显式时长：
   ```java
   sendPtt(peer, path, 2, 3500);
   ```
   气泡约 4 秒（round(3500/1000)）

## Test Plan

- [x] 旧 `sendPtt(path)` 兼容
- [x] silk 可估出合理 duration
- [x] 显式 `durationMs` 生效
- [x] 语音条可显示（非空气泡）
- [x] 文档与实现一致

## Risk Assessment

Low — 仅语音发送元数据；旧签名兼容。  
默认从「duration=0 + 空 wave」变为「自动估时长 + 非空假波形」。
